### PR TITLE
Updating eslint to 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/FoxSportsAustralia/fs-default-project-config#readme",
   "optionalDependencies": {
-    "eslint": "^4.1.1",
+    "eslint": "^4.9.0",
     "eslint-plugin-compat": "^1.0.4",
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",

--- a/resources/.eslint-nodejs-commonjs.js
+++ b/resources/.eslint-nodejs-commonjs.js
@@ -1,0 +1,19 @@
+/**
+ * Node.js and CommonJS
+ * https://eslint.org/docs/rules/#nodejs-and-commonjs
+ *
+ * These rules relate to code running in Node.js, or in browsers with CommonJS
+ */
+module.exports = {
+    "callback-return": "error",        // require return statements after callbacks
+    "global-require": "error",         // require require() calls to be placed at top-level module scope
+    "handle-callback-err": "error",    // require error handling in callbacks
+    "no-buffer-constructor": "error",  // disallow use of the Buffer() constructor
+    "no-mixed-requires": "error",      // disallow require calls to be mixed with regular variable declarations
+    "no-new-require": "error",         // disallow new operators with calls to require
+    "no-path-concat": "error",         // disallow string concatenation with __dirname and __filename
+    "no-process-env": "off",           // disallow the use of process.env
+    "no-process-exit": "error",        // disallow the use of process.exit()
+    "no-restricted-modules": "off",    // disallow specified modules when loaded by require
+    "no-sync": "off"                   // disallow synchronous methods
+};

--- a/resources/.eslintrc-es6.js
+++ b/resources/.eslintrc-es6.js
@@ -12,11 +12,6 @@ module.exports = {
     },
     "rules": {
         /**
-         * ECMASCRIPT 6
-         *
-         * These rules relate to ES6, also known as ES2015
-         */
-        /**
          * ECMASCRIPT 2015
          *
          * These rules relate to ES2015, also known as ES6
@@ -48,7 +43,7 @@ module.exports = {
           "enforceForRenamedProperties": false
         }],
         "prefer-numeric-literals": "off",             //  disallow parseInt() in favor of binary, octal, and hexadecimal literals
-        "prefer-rest-params": "off",                  //  require rest parameters instead of arguments
+        "prefer-rest-params": "error",                //  require rest parameters instead of arguments
         "prefer-spread": "error",                     //  require spread operators instead of .apply()
         "prefer-template": "off",                     //  require template literals instead of string concatenation
         "require-yield": "off",                       //  require generator functions to contain yield

--- a/resources/.eslintrc-standards--test-override.js
+++ b/resources/.eslintrc-standards--test-override.js
@@ -14,6 +14,16 @@ module.exports = {
         }, {
             "object": "it",
             "property": "only"
+        },
+        {
+            "object": "describe",
+            "property": "skip"
+        }, {
+            "object": "context",
+            "property": "skip"
+        }, {
+            "object": "it",
+            "property": "skip"
         }],
         "object-curly-spacing": "off",       // ignore object spacing, again typically JSON has spaces. We do not. But it's okay!
         "quote-props":          "off",       // ignore quotes on props, fairly common for JSON responses in tests ok!

--- a/resources/.eslintrc-standards.js
+++ b/resources/.eslintrc-standards.js
@@ -6,6 +6,7 @@ module.exports = {
          * These rules relate to possible syntax or logic errors in JavaScript code:
          */
         "for-direction": "off",                                                  // enforce “for” loop update clause moving the counter in the right direction
+        "getter-return": "error",                                                // enforce return statements in getters
         "no-await-in-loop": "off",                                               // disallow await inside of loops
         "no-compare-neg-zero": "error",                                          // disallow comparing against -0
         "no-cond-assign": "error",                                               // disallow assignment operators in conditional expressions
@@ -162,6 +163,7 @@ module.exports = {
         "func-name-matching": "off",                                                              // require function names to match the name of the variable or property to which they are assigned
         "func-names": "off",                                                                      // require or disallow named function expressions
         "func-style": "off",                                                                      // enforce the consistent use of either function declarations or expressions
+        "function-paren-newline": ["error", "consistent"],                                        // enforce consistent line breaks inside function parentheses
         "id-blacklist": "off",                                                                    // disallow specified identifiers
         "id-length": "off",                                                                       // enforce minimum and maximum identifier lengths
         "id-match": "off",                                                                        // require identifiers to match a specified regular expression
@@ -183,6 +185,7 @@ module.exports = {
         "line-comment-position": "off",                                                           //  enforce position of line comments
         "linebreak-style": ["error", "unix"],                                                     //  enforce consistent linebreak style
         "lines-around-comment": ["error", {"beforeBlockComment": true, "allowBlockStart": true}], //  require empty lines around comments
+        "lines-between-class-members": ["error", "always", { exceptAfterSingleLine: true }],      //  require empty lines around comments
         "max-depth": ["error", 3],                                                                //  enforce a maximum depth that blocks can be nested
         "max-len": ["error", {                                                                    //  enforce a maximum line length
             "code": 140,
@@ -195,7 +198,8 @@ module.exports = {
         "max-params": ["error", 5],                                                               //  enforce a maximum number of parameters in function definitions
         "max-statements": "off",                                                                  //  enforce a maximum number of statements allowed in function blocks
         "max-statements-per-line": ["error", {"max": 1}],                                         //  enforce a maximum number of statements allowed per line
-        "multiline-ternary": ["error", "never"],                                                  //  enforce newlines between operands of ternary expressions
+        "multiline-comment-style": "off",                                                         //  enforce a particular style for multiline comments
+        "multiline-ternary": ["error", "off"],                                                    //  enforce newlines between operands of ternary expressions
         "new-cap": "off",                                                                         //  require constructor names to begin with a capital letter
         "new-parens": "error",                                                                    //  require parentheses when invoking a constructor with no arguments
         "newline-per-chained-call": ["error", {"ignoreChainWithDepth": 2}],                       //  require a newline after each call in a method chain


### PR DESCRIPTION
* Turning off multiline ternary rule. Going to rely on developer common sense instead

```
{teamATable && teamBTable ? ( // eslint-disable-line multiline-ternary
    <PlayerStatsButtonRow
        key="row"
        teamAName={teamAName}
        teamBName={teamBName}
        teamAId={teamAId}
        teamBId={teamBId}
        showTeam={showTeam}
        onClickShowTeam={onClickShowTeam} />
    ) : (
        <PlayerStatsPlaceholder />
    )
)}
```

* Added commonJS/node.js rules, however note they are NOT being imported into the base package
* Added `skip` to test rule errors