### PR TITLE
Updated import & compat plugin versions & associated rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   "homepage": "https://github.com/FoxSportsAustralia/fs-default-project-config#readme",
   "optionalDependencies": {
     "eslint": "^4.9.0",
-    "eslint-plugin-compat": "^1.0.4",
+    "eslint-plugin-compat": "^2.0.1",
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-import": "^2.8.0",
     "sass-lint": "^1.10.2"
   }
 }

--- a/resources/.eslintrc-import.js
+++ b/resources/.eslintrc-import.js
@@ -35,16 +35,17 @@ module.exports = {
         "import/unambiguous": "error",                                     // Report potentially ambiguous parse goal (script vs. module)
 
         /* IMPORT: Style guide */
+        "import/exports-last": "off",                                           // Ensure all exports appear after other statements
         "import/extensions": ["error", { "js": "never", "json": "always" }],    // Ensure consistent use of file extension within the import path
         "import/first": "error",                                                // Ensure all imports appear before other statements
         "import/max-dependencies": "off",                                       // Limit the maximum number of dependencies a module can have
         "import/newline-after-import": "error",                                 // Enforce a newline after import statements
+        "import/no-anonymous-default-export": "off",                            // Forbid anonymous values as default exports
         "import/no-duplicates": "error",                                        // Report repeated import of the same module in multiple places
         "import/no-named-default": "error",                                     // Forbid named default exports
         "import/no-namespace": "error",                                         // Report namespace imports
         "import/no-unassigned-import": "error",                                 // Forbid unassigned imports
         "import/order": "error",                                                // Enforce a convention in module import order
-        "import/prefer-default-export": "error",                                // Prefer a default export if module exports a single name
-        "import/no-anonymous-default-export": "off"                             // Forbid anonymous values as default exports
+        "import/prefer-default-export": "error"                                 // Prefer a default export if module exports a single name
     }
 };


### PR DESCRIPTION
decided against turning on [imports-last](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/exports-last.md) but it was a close call

compat will continue to work as normal, just with its [own updated dependencies](https://github.com/amilajack/eslint-plugin-compat/blob/master/CHANGELOG.md)