### PR TITLE
Change dangling comma policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-default-project-config",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "description": "Repo containing commons fox sports project linting configs and editor settings",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-default-project-config",
-  "version": "6.1.4",
+  "version": "7.0.0",
   "description": "Repo containing commons fox sports project linting configs and editor settings",
   "main": "index.js",
   "scripts": {

--- a/resources/.eslintrc-standards.js
+++ b/resources/.eslintrc-standards.js
@@ -153,7 +153,7 @@ module.exports = {
         "brace-style": ["error", "1tbs", {"allowSingleLine": true}],                              // enforce consistent brace style for blocks
         "camelcase": ["error", {properties: "never"}],                                            // enforce camelcase naming convention
         "capitalized-comments": "off",                                                            // enforce or disallow capitalization of the first letter of a comment
-        "comma-dangle": ["error", "always-multiline"],                                                                  // require or disallow trailing commas
+        "comma-dangle": ["error", "always-multiline"],                                            // require or disallow trailing commas
         "comma-spacing": "error",                                                                 // enforce consistent spacing before and after commas
         "comma-style": "error",                                                                   // enforce consistent comma style
         "computed-property-spacing": "error",                                                     // enforce consistent spacing inside computed property brackets

--- a/resources/.eslintrc-standards.js
+++ b/resources/.eslintrc-standards.js
@@ -153,7 +153,7 @@ module.exports = {
         "brace-style": ["error", "1tbs", {"allowSingleLine": true}],                              // enforce consistent brace style for blocks
         "camelcase": ["error", {properties: "never"}],                                            // enforce camelcase naming convention
         "capitalized-comments": "off",                                                            // enforce or disallow capitalization of the first letter of a comment
-        "comma-dangle": "error",                                                                  // require or disallow trailing commas
+        "comma-dangle": ["error", "always-multiline"],                                                                  // require or disallow trailing commas
         "comma-spacing": "error",                                                                 // enforce consistent spacing before and after commas
         "comma-style": "error",                                                                   // enforce consistent comma style
         "computed-property-spacing": "error",                                                     // enforce consistent spacing inside computed property brackets


### PR DESCRIPTION
Never dangle on single line, always dangle on multiline

Examples of incorrect code for this rule with the “always-multiline” option:
```/*eslint comma-dangle: ["error", "always-multiline"]*/

var foo = {
    bar: "baz",
    qux: "quux"
};

var foo = { bar: "baz", qux: "quux", };

var arr = [1,2,];

var arr = [1,
    2,];

var arr = [
    1,
    2
];

foo({
  bar: "baz",
  qux: "quux"
});
```
Examples of correct code for this rule with the “always-multiline” option:
```/*eslint comma-dangle: ["error", "always-multiline"]*/

var foo = {
    bar: "baz",
    qux: "quux",
};

var foo = {bar: "baz", qux: "quux"};
var arr = [1,2];

var arr = [1,
    2];

var arr = [
    1,
    2,
];

foo({
  bar: "baz",
  qux: "quux",
});```