### PR TITLE
Require linebreaks be placed before operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-default-project-config",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Repo containing commons fox sports project linting configs and editor settings",
   "main": "index.js",
   "scripts": {

--- a/resources/.eslintrc-standards.js
+++ b/resources/.eslintrc-standards.js
@@ -230,7 +230,7 @@ module.exports = {
         "one-var": "off",                                                                         //  enforce variables to be declared either together or separately in functions
         "one-var-declaration-per-line": "off",                                                    //  require or disallow newlines around variable declarations
         "operator-assignment": "off",                                                             //  require or disallow assignment operator shorthand where possible
-        "operator-linebreak": ["error", "after"],                                                 //  enforce consistent linebreak style for operators
+        "operator-linebreak": ["error", "before"],                                                //  enforce consistent linebreak style for operators
         "padded-blocks": ["error", "never"],                                                      //  require or disallow padding within blocks
         "padding-line-between-statements": ["error",                                              //  require or disallow padding lines between statements
             { blankLine: "always", prev: "*", next: "return" },


### PR DESCRIPTION
This makes multi-line expressions more maintainable when lines are split on operators, especially `+` and `-`.

Consider this example:

```js
const x =
    a +
    b -
    c +
    d
; // eslint-disable-line semi-style
```

If I want to remove one of the terms, I can't simply remove a line, because the sign is part of the term which continues on the next line. However, if it's reformatted like this:

```js
const x =
    a
    + b
    - c
    + d
; // eslint-disable-line semi-style
```

I can remove one of the terms simply by removing a line. It also makes reordering easier and less prone to bugs.